### PR TITLE
Add support for remote urls with a `ssh://` prefix.

### DIFF
--- a/plugin/fubitive.vim
+++ b/plugin/fubitive.vim
@@ -12,7 +12,7 @@ function! s:bitbucket_url(opts, ...) abort
   for domain in domains
     let domain_pattern .= '\|' . escape(split(domain, '://')[-1], '.')
   endfor
-  let repo = matchstr(a:opts.remote,'^\%(https\=://\|git://\|git@\)\zs\('.domain_pattern.'\)[/:].\{-\}\ze\%(\.git\)\=$')
+  let repo = matchstr(a:opts.remote,'^\%(https\=://\|git://\|\(ssh://\)\=git@\)\zs\('.domain_pattern.'\)[/:].\{-\}\ze\%(\.git\)\=$')
   if repo ==# ''
     return ''
   endif


### PR DESCRIPTION
The Bitbucket documentation sometimes tell the user to specify the remote url for the repo as `ssh://git@bitbucket.org:user/repo.git` (for example, https://confluence.atlassian.com/display/BITBUCKET/Import+code+from+an+existing+project and https://confluence.atlassian.com/display/BITBUCKET/Use+the+SSH+protocol+with+Bitbucket). This pattern is not handled by the regex at https://github.com/tommcdo/vim-fubitive/blob/master/plugin/fubitive.vim#L15.

Here is a patch with an updated regex to handle these urls.
