### PR TITLE
Update link anchor format for line numbers

### DIFF
--- a/plugin/fubitive.vim
+++ b/plugin/fubitive.vim
@@ -51,7 +51,7 @@ function! s:bitbucket_url(opts, ...) abort
   elseif a:opts.type == 'blob'
     let url = root . '/src/' . commit . '/' . path
     if get(a:opts, 'line1')
-      let url .= '#cl-' . a:opts.line1
+      let url .= '#' . path . '-' . a:opts.line1
     endif
   elseif a:opts.type == 'tag'
     let commit = matchstr(getline(3),'^tag \zs.*')


### PR DESCRIPTION
Bitbucket has changed the structure of anchor links for line numbers. Instead of:

```
https://bitbucket.org/duangle/none/src/223dedbcd5eb7396534f6553af9ac47a5cbdcaf5/src/none/ismain.lua?at=default#cl-2
```
```
https://bitbucket.org/duangle/none/src/223dedbcd5eb7396534f6553af9ac47a5cbdcaf5/src/none/ismain.lua?at=default#ismain.lua-2
```