### PR TITLE
fix https bitbucket url regex of the form https://[username]@bitbucke…

### DIFF
--- a/plugin/fubitive.vim
+++ b/plugin/fubitive.vim
@@ -12,7 +12,7 @@ function! s:bitbucket_url(opts, ...) abort
   for domain in domains
     let domain_pattern .= '\|' . escape(split(domain, '://')[-1], '.')
   endfor
-  let repo = matchstr(a:opts.remote,'^\%(https\=://\|git://\|\(ssh://\)\=git@\)\zs\('.domain_pattern.'\)[/:].\{-\}\ze\%(\.git\)\=$')
+  let repo = matchstr(a:opts.remote,'^\%(https\=://\|git://\|\(ssh://\)\=git@\)\%(.\{-\}@\)\=\zs\('.domain_pattern.'\)[/:].\{-\}\ze\%(\.git\)\=$')
   if repo ==# ''
     return ''
   endif


### PR DESCRIPTION
…t.org/[username]/[repo name].git -- missing the "[username]@" part

`:Gbrowse` wasn't working for my bitbucket https urls. I kept getting `fugitive: "origin' is not a supported remote`.
I realised that the regex on `line 15` was missing the 'username@' part of 'https://username@bitbucket.org...'. 
Added `\%(.\{-\}@\)\=` and now it works. Not 100% sure if this is the best regex to do this and hopefully it won't mess up anything else but I can now `:Gbrowse` with my bitbucket project.