### PR TITLE
Extract protocol from remote

### DIFF
--- a/plugin/fubitive.vim
+++ b/plugin/fubitive.vim
@@ -27,9 +27,13 @@ function! s:bitbucket_url(opts, ...) abort
     let project = matchstr(repo, '\zs\([^/]*\)\ze/[^/]*$')
     let repo = matchstr(repo, '/\zs\([^/]*\)$')
   endif
+  let protocol = matchstr(a:opts.remote,'^\(https\=://\)')
+  if protocol->empty()
+      let protocol = 'https://'
+  endif
   let root = is_cloud
-        \ ? 'https://' . substitute(repo, ':', '/', '')
-        \ : 'https://' . domain . '/projects/' . project . '/repos/' . repo
+        \ ? protocol . substitute(repo, ':', '/', '')
+        \ : protocol . domain . '/projects/' . project . '/repos/' . repo
   if path =~# '^\.git/refs/heads/'
     return root . '/commits/' . path[16:-1]
   elseif path =~# '^\.git/refs/tags/'


### PR DESCRIPTION
Should solve #20.

Not all bitbucket URL's are behind `SSL` so this should make it work with both those with, and those without `SSL`.

@petrisch could you please just check this branch once more to make sure it's working? I refactored it a bit after last time you tested it, so I just want to make doubly sure it's working :)