### PR TITLE
Fix 32: parse commit from current object or use HEAD

### DIFF
--- a/plugin/fubitive.vim
+++ b/plugin/fubitive.vim
@@ -53,7 +53,8 @@ function! s:bitbucket_url(opts, ...) abort
           \ ? substitute(root . '/src/' . commit . '/' . path, '/$', '', '')
           \ : substitute(root . '/browse/' . path . '?at=' . commit, '/$', '', '')
   elseif get(a:opts, 'type', '') ==# 'blob' || a:opts.path =~# '[^/]$'
-    let commit = fugitive#RevParse('HEAD')
+    let objSpec = split(fugitive#Object(), ':')
+    let commit = len(objSpec) == 2 ? objSpec[0] : fugitive#RevParse('HEAD')
     let url = is_cloud
           \ ? root . '/src/' . commit . '/' . path
           \ : root . '/browse/' . path . '?at=' . commit


### PR DESCRIPTION
If there is a revision associated with the current object, use that. Else fall back to using HEAD revision.