### PR TITLE
Allow setting default protocol to http

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ your `.vimrc`.
 let g:fubitive_domain_pattern = 'code\.example\.com'
 let g:fubitive_domain_context_path = 'bitbucket'
 ```
+
+By default, fubitive will assume `https://` when building URLs. 
+To change this, set the `g:fubitive_default_protocol` variable:
+
+```vim
+let g:fubitive_default_protocol = 'http://'
+```

--- a/plugin/fubitive.vim
+++ b/plugin/fubitive.vim
@@ -7,6 +7,12 @@ function! s:function(name) abort
   return function(substitute(a:name,'^s:',matchstr(expand('<sfile>'), '<SNR>\d\+_'),''))
 endfunction
 
+function! s:default_protocol()
+  return exists('g:fubitive_default_protocol')
+    \ ? g:fubitive_default_protocol
+    \ : 'https://'
+endfunction
+
 function! s:domain_context_path()
   return exists('g:fubitive_domain_context_path')
     \ ? '/' . g:fubitive_domain_context_path
@@ -35,7 +41,7 @@ function! s:bitbucket_url(opts, ...) abort
   endif
   let protocol = matchstr(a:opts.remote,'^\(https\=://\)')
   if empty(protocol)
-      let protocol = 'https://'
+      let protocol = s:default_protocol()
   endif
   let root = protocol . (is_cloud
         \ ? substitute(repo, ':', '/', '')


### PR DESCRIPTION
I'm currently working for a client who has a self-hosted Bitbucket instance where the web UI is http-only 💀. Because of that, I needed a way to override the default protocol for URL building to http, from https.

This could use some documentation, but wanted to get your input on direction first before cleaning it up.

Usage example: `let g:fubitive_default_protocol = 'http://'`